### PR TITLE
Run the status page on it's own port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN \
   echo 'MaxConnectionsPerChild ${MAXCONNECTIONSPERCHILD}' >> /etc/apache2/apache2.conf && \
   sed -i -e 's/Listen 80/Listen 8080/g' /etc/apache2/ports.conf && \
   sed -i -e 's/Listen 443/#Listen 8443/g' /etc/apache2/ports.conf && \
+  echo "Listen 8081" >> /etc/apache2/ports.conf && \
   a2enmod deflate rewrite ssl headers macro rpaf cgi expires include && \
   a2disconf other-vhosts-access-log && \
   a2enconf vhosts-logging && \

--- a/files/etc/apache2/mods-available/status.conf
+++ b/files/etc/apache2/mods-available/status.conf
@@ -1,0 +1,18 @@
+<IfModule mod_status.c>
+	Listen 8081
+
+	<Location /server-status>
+		SetHandler server-status
+		Require ip 127.0.0.1
+	</Location>
+
+	# Keep track of extended status information for each request
+	ExtendedStatus On
+
+	<IfModule mod_proxy.c>
+		# Show Proxy LoadBalancer status in mod_status
+		ProxyStatus On
+	</IfModule>
+
+
+</IfModule>


### PR DESCRIPTION
Derivative images allow breakage of the status page otherwise